### PR TITLE
Use new Guard 2.0 api

### DIFF
--- a/lib/guard/spring.rb
+++ b/lib/guard/spring.rb
@@ -1,16 +1,15 @@
 require 'guard'
-require 'guard/guard'
+require 'guard/plugin'
 require 'spring/commands'
 
 module Guard
-  class Spring < Guard
+  class Spring < Plugin
     autoload :Runner, 'guard/spring/runner'
     attr_accessor :runner
 
     # Initialize a Guard.
-    # @param [Array<Guard::Watcher>] watchers the Guard file watchers
     # @param [Hash] options the custom Guard options
-    def initialize(watchers = [], options = {})
+    def initialize(options = {})
       super
       @runner = Runner.new(options)
     end


### PR DESCRIPTION
`require 'guard/plugin'` instead of `'guard/guard'`

`Spring` class now inherits from `Plugin` instead of `Guard`.

Changed method signature of `Spring#initialize`

Updated `#initialize` docs.